### PR TITLE
Refactor HttpClient usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>1.1.1</VersionPrefix>
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)assets/Passage.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>

--- a/src/Passage.Extensions.DependencyInjection/InjectablePassageClient.cs
+++ b/src/Passage.Extensions.DependencyInjection/InjectablePassageClient.cs
@@ -14,8 +14,8 @@ public class InjectablePassageClient : Passage
     public InjectablePassageClient(IOptions<PassageConfig> options, HttpClient httpClient)
         : base(options.Value)
     {
-        this._httpClient = httpClient;
-        this._httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.Value.ApiKey);
-        this._httpClient.DefaultRequestHeaders.Add("Passage-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+        this.HttpClient = httpClient;
+        this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.Value.ApiKey);
+        this.HttpClient.DefaultRequestHeaders.Add("Passage-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
     }
 }

--- a/src/Passage.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Passage.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ServiceCollectionExtensions
                 }
             });
 
-        services.TryAddTransient<IPassage>(resolver => resolver.GetRequiredService<InjectablePassageClient>());
+        services.TryAddSingleton<IPassage>(resolver => resolver.GetRequiredService<InjectablePassageClient>());
 
         return services.AddHttpClient<InjectablePassageClient>();
     }

--- a/src/Passage/Passage.cs
+++ b/src/Passage/Passage.cs
@@ -9,7 +9,7 @@ public class Passage : IPassage
     private readonly string _apiKey = string.Empty;
     private readonly AuthStrategy _authStrategy;
     private JsonWebKeySet _jwks;
-    protected HttpClient _httpClient;
+    protected HttpClient HttpClient;
 
     /// <summary>
     /// Passage class constructor
@@ -41,7 +41,7 @@ public class Passage : IPassage
     /// <exception cref="PassageException"></exception>
     public Passage(PassageConfig config, HttpClient httpClient) : this(config)
     {
-        _httpClient = httpClient;
+        HttpClient = httpClient;
     }
 
     /// <summary>
@@ -274,9 +274,9 @@ public class Passage : IPassage
 
     private HttpClient GetHttpClient()
     {
-        if (_httpClient is not null)
+        if (HttpClient is not null)
         {
-            return _httpClient;
+            return HttpClient;
         }
         
         if (string.IsNullOrEmpty(_apiKey))
@@ -284,11 +284,11 @@ public class Passage : IPassage
             throw new PassageException(Errors.Config.MissingApiKey);
         }
         
-        _httpClient = new HttpClient();
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
-        _httpClient.DefaultRequestHeaders.Add("Passage-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
+        HttpClient = new HttpClient();
+        HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        HttpClient.DefaultRequestHeaders.Add("Passage-Version", Assembly.GetExecutingAssembly().GetName().Version.ToString());
 
-        return _httpClient;
+        return HttpClient;
     }
 
     private static string GetKidFromJwtToken(string token)
@@ -300,8 +300,7 @@ public class Passage : IPassage
 
     private async Task<JsonWebKeySet> DownloadJWKS()
     {
-        using var httpClient = new HttpClient();
-        var jwks = await httpClient.GetStringAsync($"https://auth.passage.id/v1/apps/{_appId}/.well-known/jwks.json");
+        var jwks = await GetHttpClient().GetStringAsync($"https://auth.passage.id/v1/apps/{_appId}/.well-known/jwks.json");
 
         if (string.IsNullOrEmpty(jwks))
             throw new PassageException(Errors.Token.CannotDownloadJwks);


### PR DESCRIPTION
This commit updates the project version from 1.1.0 to 1.1.1. Changes are also made to refactor the usage of HttpClient across the application, mainly making it a protected property rather than a private variable. In the ServiceCollectionExtensions file, the lifetime scope of IPassage service has been changed from Transient to Singleton.